### PR TITLE
Update pip install url in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This runs on Python >=3.6 with recent [pySerial](https://github.com/pyserial/pys
 
 To install, if you have pip and want system-wide:
 
-    pip install git+git://github.com/toniebox-reverse-engineering/cc3200tool.git
+    pip install git+https://github.com/toniebox-reverse-engineering/cc3200tool.git
 
 or clone this repǫ
 


### PR DESCRIPTION
the pip install progress needs an update as Github changed git:// to https://