### PR TITLE
correct slash "direction" (windows style to posix)

### DIFF
--- a/cc3200tool/cc.py
+++ b/cc3200tool/cc.py
@@ -1320,7 +1320,7 @@ class CC3200Connection(object):
         for root, dirs, files in os.walk(local_dir):
             for file in files:
                 filepath = os.path.join(root, file)
-                ccpath = filepath[len(local_dir):]
+                ccpath = filepath[len(local_dir):].replace("\\","/")
                 if not ccpath.startswith("/"):
                     ccpath = "/" + ccpath
 


### PR DESCRIPTION
See Issue #24 


Tested locally and got correct cc filenames:
![image](https://github.com/toniebox-reverse-engineering/cc3200tool/assets/3179296/08adc5cc-1d01-4e99-9846-e3000cb38e27)
